### PR TITLE
Change from raw.github.com to rawgithub.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ $(document).ready(function () {
     <!--[if !IE]><script>fixScale(document);</script><![endif]-->
 
   </body>
-  <script src="https://raw.github.com/gregstewart/orbital-dial/master/dist/orbital-dial.min.js"></script>
+  <script src="https://rawgithub.com/gregstewart/orbital-dial/master/dist/orbital-dial.min.js"></script>
   <script>
       $(document).ready(function () {
           var orbitalDial = new OrbitalDial({outerSelector: '#OuterSlider'


### PR DESCRIPTION
On javascript console on the demo page I get this error :

```
Refused to execute script from 'https://raw.github.com/gregstewart/orbital-dial/master/dist/orbital-dial.min.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled. (index):1
Uncaught TypeError: object is not a function 
```
